### PR TITLE
Improve (n)curses dependency detection

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -1,4 +1,4 @@
-curses_dep = dependency('ncurses')
+curses_dep = dependency('curses')
 sfml_dep = dependency('sfml-audio')
 th_dep = dependency('threads')
 deps = [curses_dep, sfml_dep]


### PR DESCRIPTION
Meson has a [builtin special `curses` dependency](https://mesonbuild.com/Dependencies.html#curses) that can detect various curses and ncurses variants. Switching to it makes the program buildable for systems which have ncursesw and not ncurses.

By the way this is a really nice program! It is surprisingly hard to find programs working with Lrc for Linux. I might look into this program more if I'll have spare time.