### PR TITLE
Make lrc-gen installable

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -3,4 +3,4 @@ sfml_dep = dependency('sfml-audio')
 th_dep = dependency('threads')
 deps = [curses_dep, sfml_dep]
 sources = ['main.cpp', 'lrc-generator.cpp', 'lrc-interface.cpp', 'loguru.cpp']
-executable('lrc-gen', sources, dependencies: deps, include_directories: includes)
+executable('lrc-gen', sources, dependencies: deps, include_directories: includes, install: true)


### PR DESCRIPTION
`lrc-gen` is this project's main executable, therefore it should be installable.

This change would make lrc-generator more easily packagable for Linux distros.